### PR TITLE
Fix simple and nested any

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -485,6 +485,29 @@ PRETTY_PRINT_EXPECTATIONS = (
 '''.strip()
 ],
 
+# simple + nested Any inside an all
+[
+'''
+{
+  val1 = 10
+  [
+    val2 = 20
+    val3 = 30
+  ]
+}
+''',
+'{"val1"=10,["val2"=20,"val3"=30]}',
+'''
+{
+    "val1"=10
+    [
+      "val2"=20
+      "val3"=30
+    ]
+}
+'''.strip()
+],
+
 )
 
 class PrettyPrintingTests(unittest.TestCase):

--- a/test/tests.py
+++ b/test/tests.py
@@ -398,7 +398,7 @@ PRETTY_PRINT_EXPECTATIONS = (
     val1 = 10
     val2 = 20
   }
-} 
+}
 ''',
 '{"val1"=10,"val2"=20}',
 '''
@@ -499,11 +499,11 @@ PRETTY_PRINT_EXPECTATIONS = (
 '{"val1"=10,["val2"=20,"val3"=30]}',
 '''
 {
-    "val1"=10
-    [
-      "val2"=20
-      "val3"=30
-    ]
+  "val1" = 10
+  [
+    "val2" = 20
+    "val3" = 30
+  ]
 }
 '''.strip()
 ],


### PR DESCRIPTION
Added a test that fails for `dense=True`, [line #45] (https://github.com/mediapredict/daffodil/blob/master/daffodil/pretty_print.py#L45)