### PR TITLE
test reproducing the postgres error in production

### DIFF
--- a/daffodil/__init__.py
+++ b/daffodil/__init__.py
@@ -129,7 +129,7 @@ class Daffodil(object):
         return children[0]
     
     def integer(self, node, children):
-        'integer = ~"[0-9]+"'
+        'integer = ~"-?[0-9]+"'
         return int(node.text)
     
     def boolean(self, node, children):
@@ -139,7 +139,7 @@ class Daffodil(object):
         return node.text.lower() == "true"
     
     def float(self, node, children):
-        'float = ~"[0-9]*\.[0-9]+"'
+        'float = ~"-?[0-9]*\.[0-9]+"'
         return float(node.text)
 
     def _(self, node, children):

--- a/daffodil/hstore_predicate.py
+++ b/daffodil/hstore_predicate.py
@@ -38,28 +38,29 @@ class HStoreQueryDelegate(object):
             val = "'{0}'".format(key)
             key = "{0}{1}".format(negate, self.field)
         else:
-            cast, val = self.cond_cast(val)
+            cast, val, type_check = self.cond_cast(val)
             if getattr(test, "is_NE_test", False):
                 # here we cover:
                 # NOT (hstore_col?'wrong attribute') OR (hstore_col->'wrong attribute')::integer != 2
-                key_format = "NOT ({0}?'{1}') OR ({0}->'{1}'){2}"
+                key_format = "NOT ({0}?'{1}') OR {3} ({0}->'{1}'){2} {4}"
             elif getattr(test, "is_EQ_test", False):
                 # here we convert '=' to '? AND =':
                 # hs_answers?'industries - luxury' AND hs_answers->'industries - luxury' = 'yes'
-                key_format = "({0}?'{1}') AND ({0}->'{1}'){2}"
+                key_format = "({0}?'{1}') AND {3} ({0}->'{1}'){2} {4}"
             else:
-                key_format = "({0}->'{1}'){2}"
+                key_format = "{3} ({0}->'{1}'){2} {4}"
 
-            key = key_format.format(self.field, key, cast)
+            key = key_format.format(self.field, key, cast, type_check[0], type_check[1]).format(self.field, key, cast)
         return test( key, val )
 
     def cond_cast(self, v):
         if isinstance(v, int):
-            return "::integer", unicode(v)
+            # making sure attribute really holds an integer value
+            return "::integer", unicode(v), ["CASE WHEN ({0}->'{1}' ~ E'^\\\d+$') THEN ", "ELSE -2147483648 END"]
         elif isinstance(v, float):
-            return "::real", unicode(v)
+            return "::real", unicode(v), ["", ""]
         else:
-            return "", u"'{0}'".format(v)
+            return "", u"'{0}'".format(v), ["", ""]
 
     def call(self, predicate, queryset):
         return queryset.extra(where=[predicate]) if predicate else queryset

--- a/test/tests.py
+++ b/test/tests.py
@@ -275,6 +275,35 @@ class SATDataTests(unittest.TestCase):
         self.assert_filter_has_n_results(421, """
             dbn != 7
         """)
+        self.assert_filter_has_n_results(0, """
+            dbn = -7
+        """)
+        self.assert_filter_has_n_results(0, """
+            dbn > -7
+        """)
+        self.assert_filter_has_n_results(421, """
+            dbn != -7
+        """)
+    
+    def test_comparing_string_data_to_a_float_filter(self):
+        self.assert_filter_has_n_results(0, """
+            dbn = 7.5
+        """)
+        self.assert_filter_has_n_results(0, """
+            dbn > 7.5
+        """)
+        self.assert_filter_has_n_results(421, """
+            dbn != 7.5
+        """)
+        self.assert_filter_has_n_results(0, """
+            dbn = -7.5
+        """)
+        self.assert_filter_has_n_results(0, """
+            dbn > -7.5
+        """)
+        self.assert_filter_has_n_results(421, """
+            dbn != -7.5
+        """)
 
 
 class PredicateTests(unittest.TestCase):


### PR DESCRIPTION
Basically if you try to write a daffodil like:

```
{
  "a" = 14
}
```

…and you have data for "a" in one of your records like `"a"->"never"` the query will error.

But it _should_ just consider that to **not match the filter**