### PR TITLE
downgrading: without a check if an integer attr exists

### DIFF
--- a/daffodil/hstore_predicate.py
+++ b/daffodil/hstore_predicate.py
@@ -62,11 +62,7 @@ class HStoreQueryDelegate(object):
 
     def cond_cast(self, v):
         if isinstance(v, int):
-            attr_check = [
-                "({0}->'{1}') ~ E'^[-]?\\\d+$'", " AND ",   # type
-                "({0} ? '{1}')", " AND "                    # existence
-            ]
-            return "::integer", unicode(v), attr_check
+            return "::integer", unicode(v), ["({0}->'{1}') ~ E'^[-]?\\\d+$'", " AND ",]
         elif isinstance(v, float):
             return "::numeric", unicode(v), ["({0}->'{1}') ~ E'^(?=.+)(?:[1-9]\\\d*|0)?(?:\\\.\\\d+)?$'", " AND "]
         else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='daffodil',
-    version='0.3.2',
+    version='0.3.1',
     author='James Robert',
     description='A Super-simple DSL for filtering datasets',
     license='MIT',


### PR DESCRIPTION
That's a pending thing - downgrades daffodil back to ver 0.3.1 after tests have shown that in some cases _integer attribute existence check_ ruins the performance.

As listed here: #12