### PR TITLE
Fix not containing

### DIFF
--- a/daffodil/hstore_predicate.py
+++ b/daffodil/hstore_predicate.py
@@ -21,7 +21,7 @@ def breaks_optimizer(expr):
 
     return (
         expr.daff_test in {"!=", "!in"} or
-        (expr.daff_test == "?=" and expr.daff_val == "false") or
+        (expr.daff_test == "?=" and expr.daff_val == False) or
         (expr.daff_test == "=" and isinstance(expr.daff_val, basestring))
     )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='daffodil',
-    version='0.3.10',
+    version='0.3.11',
     author='James Robert',
     description='A Super-simple DSL for filtering datasets',
     license='MIT',

--- a/test/tests.py
+++ b/test/tests.py
@@ -472,7 +472,39 @@ class SATDataTests(unittest.TestCase):
         self.assert_filter_has_n_results(421, u"""
             'asdf' ?= false
         """)
-    
+
+    def test_existance_multiple(self):
+        self.assert_filter_has_n_results(421, u"""
+            [
+                total_score ?= true
+                num_of_sat_test_takers ?= true
+            ]
+        """)
+        self.assert_filter_has_n_results(421, u"""
+            [
+                total_score ?= false
+                num_of_sat_test_takers ?= true
+            ]
+        """)
+        self.assert_filter_has_n_results(0, u"""
+            {
+                total_score ?= false
+                num_of_sat_test_takers ?= false
+            }
+        """)
+        self.assert_filter_has_n_results(4, u"""
+            {
+                total_score ?= true
+                num_of_sat_test_takers ?= true
+            }
+        """)
+        self.assert_filter_has_n_results(417, u"""
+            {
+                total_score ?= false
+                num_of_sat_test_takers ?= true
+            }
+        """)
+
     def test_comparing_string_data_to_an_int_filter(self):
         self.assert_filter_has_n_results(0, """
             dbn = 7


### PR DESCRIPTION
Daffodil `?= false` expressions within `all` or `any` blocks were interpreted wrong. So for an expression like:

```
"wnbcpromo_bq1" ?= true
"kntvpromo_bq2" ?= false
```
... we were getting:
```
SELECT * FROM "my_table" 
WHERE (hs_data ?& ARRAY['wnbcpromo_bq1','kntvpromo_bq2']);
```

