### PR TITLE
daffodil bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ env
 *.swp
 /*.egg-info/
 /.idea
+/build

--- a/daffodil/parser.py
+++ b/daffodil/parser.py
@@ -71,10 +71,9 @@ class DaffodilParser(object):
     def main(self):
         can_accept_another_expression = True
         expected_closers = []
-        while self.pos < self.end:
-            # skip over non-significant whitespace
-            self.consume_whitespace()
 
+        self.consume_whitespace()
+        while self.pos < self.end:
             c = self.char()
 
             # Fist deal with All/Any/Not All/Not Any right in the main loop...
@@ -103,6 +102,9 @@ class DaffodilParser(object):
                 can_accept_another_expression = self.condition()
             else:
                 raise ParseError("Unrecognized input at byte {}".format(self.pos))
+
+            # skip over non-significant whitespace
+            self.consume_whitespace()
 
     def comment(self, token_type):
         buffer = ""
@@ -266,7 +268,7 @@ class DaffodilParser(object):
         while self.pos < end:
             self.consume_whitespace(newlines=sep_found)
             c = src[self.pos]
-            if c == '\n':
+            if c in '\r\n':
                 sep_found = True
             elif c == ',':
                 if comma_found:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     keywords='data filtering',
     url='https://github.com/mediapredict/daffodil',
     packages=['daffodil'],
-    install_requires=[],
+    install_requires=['future'],
     long_description='A Super-simple DSL for filtering datasets',
     classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/test/tests.py
+++ b/test/tests.py
@@ -1153,7 +1153,17 @@ r"v='\'a'",
 '''.strip(),
 ],
 
-
+# Daffodil separated with carraige return, line feed
+[
+u'"metropcs_precamp_qxthanks" ?= true\r\n"source" != "test"',
+u'{"metropcs_precamp_qxthanks"?=true,"source"!="test"}',
+'''
+{
+  "metropcs_precamp_qxthanks" ?= true
+  "source" != "test"
+}
+'''.strip()
+],
 
 # Complex, unordered, badly indented and nested
 [
@@ -1167,6 +1177,7 @@ val2 ?= true
 val6 ?= true
       val5 = 30
     }
+       # words!   
   {
     val5 ?= true
     val5 != 30
@@ -1185,6 +1196,7 @@ val6 ?= true
       "val6" ?= true
       "val5" = 30
     }
+    # words!
     {
       "val5" ?= true
       "val5" != 30

--- a/test/tests.py
+++ b/test/tests.py
@@ -455,6 +455,25 @@ class SATDataTests(BaseTest):
         self.assertRaises(ParseError, Daffodil, """
             [
         """)
+        self.assertRaises(ParseError, Daffodil, """
+            {
+              a = 1
+              b = 2
+            } {
+              x = 3
+              y = 4
+            }
+        """)
+        self.assertRaises(ParseError, Daffodil, """
+            [
+              a = 1
+              b = 2
+            ] [
+              c = 3
+              d = 4
+            ]
+        """)
+
 
     def test_unicode_filter(self):
         self.assert_filter_has_n_results(273, """


### PR DESCRIPTION
I am running this script with old and new daffodil and comparing the outputs:
```python
import os
import sys
from collections import defaultdict

import django

sys.path.extend(['/Users/jiaaro/code/knittingfactory', '/Users/jiaaro/code/knittingfactory/src', '/Applications/PyCharm.app/Contents/helpers/pycharm', '/Applications/PyCharm.app/Contents/helpers/pydev'])
os.environ['DJANGO_SETTINGS_MODULE'] = 'src.settings'
django.setup()

import json
import time
import random
from daffodil import Daffodil
from daffodil.exceptions import ParseError

from stitcher.models import Participant
from terminator.models import ConditionalRouterRoute, RandomizerRoute, Quota

daffs = set()
daffs |= set(ConditionalRouterRoute.objects.values_list('data_filter', flat=True))
daffs |= set(RandomizerRoute.objects.values_list('data_filter', flat=True))
daffs |= set(Quota.objects.values_list("group_data_filter", flat=True))
daffs |= set(DerivedColumnExpression.objects.values_list("expression", flat=True))

random.seed(1773)
max_id = Participant.objects.latest("id").id
kfpds = Participant.objects.filter(id__in=[random.randint(1, max_id) for i in range(5000)]).values_list("id", "hs_data")

start = time.time()
output = defaultdict(set)
for daff in daffs:
    try:
        d = Daffodil(daff)
    except ParseError:
        output[daff] = "ParseError"
        continue

    try:
        for kfid, kfpd in kfpds:
            if d.predicate(kfpd):
                output[daff].add(kfid)
    except:
        print "FAILED ON:", kfid
        print kfpd
        print "DAFF:"
        print daff
        raise

print "elapsed: {:0.1f}s".format(time.time() - start)


with open("./{}.json".format(int(time.time())), 'w') as f:
    json.dump(output, f, sort_keys=True, indent=2, default=lambda v: sorted(v))
```