### PR TITLE
Fix parsing bug with unmatched closing braces

### DIFF
--- a/daffodil/parser.py
+++ b/daffodil/parser.py
@@ -90,6 +90,8 @@ class DaffodilParser(object):
                 expected_closers.append(PAIRS[c])
                 self.pos += 1
             elif c in '}]':
+                if not expected_closers:
+                    raise ParseError("Found an closing brace \"{}\" without a corresponding opening brace.".format(c))
                 if c != expected_closers[-1]:
                     raise ParseError("Expected a {} but found {} instead".format(expected_closers[-1], c))
                 self.tokens.append(GroupEnd(c))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='daffodil',
-    version='0.3.19',
+    version='0.3.20',
     author='James Robert',
     description='A Super-simple DSL for filtering datasets',
     license='MIT',

--- a/test/tests.py
+++ b/test/tests.py
@@ -488,6 +488,10 @@ class SATDataTests(BaseTest):
               d = 4
             ]
         """)
+        self.assertRaises(ParseError, Daffodil, "a = 1 }")
+        self.assertRaises(ParseError, Daffodil, "a = 1 ]")
+        self.assertRaises(ParseError, Daffodil, "a = 1 \n}")
+        self.assertRaises(ParseError, Daffodil, "a = 1 \n]")
 
 
     def test_unicode_filter(self):


### PR DESCRIPTION
Before this fix the wrong exception was raised. Now it raises a ParseError like it should