### PR TITLE
remove type requirement in python predicate

### DIFF
--- a/daffodil/predicate.pyx
+++ b/daffodil/predicate.pyx
@@ -38,10 +38,10 @@ cdef class CMPFunctionHandler:
     cdef object val
     cdef bint err_ret_val
 
-    def __call__(self, dict data_point):
+    def __call__(self, object data_point):
         return self._call(data_point)
 
-    cdef bint _call(self, dict data_point):
+    cdef bint _call(self, object data_point):
         cdef object dp_val
         cdef object cmp_val
 
@@ -80,7 +80,7 @@ cdef class CMPFunctionHandler:
 
 
 cdef class DPCMPFunctionHandler(CMPFunctionHandler):
-    cdef bint _call(self, dict data_point):
+    cdef bint _call(self, object data_point):
         if data_point is None:
             return not self.val
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if cython_installed:
 
 setup(
     name='daffodil',
-    version='0.5.2',
+    version='0.5.3',
     author='James Robert',
     description='A Super-simple DSL for filtering datasets',
     license='MIT',


### PR DESCRIPTION
HStoreDict and other dict-like objects and subclasses should be allowed as well as actual python dict instances