### PR TITLE
just ver in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if cython_installed:
 
 setup(
     name='daffodil',
-    version='0.5.5',
+    version='0.5.6',
     author='James Robert',
     description='A Super-simple DSL for filtering datasets',
     license='MIT',


### PR DESCRIPTION
Reason for the PR: setup.py version not matching Github version.

After this PR is merged, the current `v0.5.6` should be dropped and then recreated with the same description: "Return False when a key with null value is evaluated"