### PR TITLE
Bump django from 3.2.12 to 4.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Cython==0.29.22
 psycopg2-binary==2.8.5
-Django==3.2.12
+Django==4.0.4

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extra_kwargs = {
 
 setup(
     name='daffodil',
-    version='0.5.16',
+    version='0.5.17',
     author='James Robert',
     description='A Super-simple DSL for filtering datasets',
     license='MIT',


### PR DESCRIPTION
[#2812](https://github.com/mediapredict/mediapredict/issues/2812)
- Bumps [django ](https://github.com/django/django)from 3.2.12 to 4.0.4 
- Increased minor version to 0.5.17