### PR TITLE
optimize mixed str/int content

### DIFF
--- a/daffodil/hstore_predicate.pyx
+++ b/daffodil/hstore_predicate.pyx
@@ -108,7 +108,10 @@ cdef class HStoreQueryDelegate(BaseDaffodilDelegate):
 
     def optimize_equality_and(self, children, sql_expr):
         to_optimize = [child_exp for child_exp in children if child_exp.daff_test == "="]
-        if len({child_exp.daff_key for child_exp in to_optimize}) <= 1:
+        keys = [child_exp.daff_key for child_exp in to_optimize]
+        unique_keys = set(keys)
+
+        if len(unique_keys) < 2 or len(keys) != len(unique_keys):
             return sql_expr
 
         keys_and_values = ", ".join(

--- a/daffodil/hstore_predicate.pyx
+++ b/daffodil/hstore_predicate.pyx
@@ -58,7 +58,7 @@ def breaks_equality_optimizer(children):
 
     return len([
         True for child_exp in children
-        if child_exp.daff_test == "=" and isinstance(child_exp.daff_val, str)
+        if child_exp.daff_test == "=" and isinstance(child_exp.daff_val, (str, int))
     ]) < 2
 
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -314,6 +314,15 @@ class SATDataTests(BaseTest):
             }
         """)
 
+        # reproduce a bug - repeated key in AND expression
+        self.assert_filter_has_n_results(3, """
+            {
+                updated = "1714724220"
+                zip_code = "10019"
+                zip_code = "9999999999"
+            }
+        """)
+
         # optimized, while keeping existence test out of optimization
         self.assert_filter_has_n_results(1, """
             {

--- a/test/tests.py
+++ b/test/tests.py
@@ -298,7 +298,7 @@ class SATDataTests(BaseTest):
         """)
 
     def test_optimization_string_equality(self):
-        # just one key - skip block level optimization
+        # skip opimization - just one unique key
         self.assert_filter_has_n_results(4, """
             {
                 updated = "1714724220"
@@ -320,6 +320,23 @@ class SATDataTests(BaseTest):
                 updated = "1714724220"
                 dbn = "02M296"
                 not_existing_param ?= false
+            }
+        """)
+
+        # optimized, equality with mixed content, int + str
+        self.assert_filter_has_n_results(3, """
+            {
+                updated = 1714724220
+                zip_code = "10019"
+            }
+        """)
+
+        # skip optimization, integers only so "existence optimization"
+        # kicks in first
+        self.assert_filter_has_n_results(3, """
+            {
+                updated = 1714724220
+                zip_code = 10019
             }
         """)
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -298,28 +298,11 @@ class SATDataTests(BaseTest):
         """)
 
     def test_optimization_string_equality(self):
-        # skip opimization - just one unique key
-        self.assert_filter_has_n_results(4, """
-            {
-                updated = "1714724220"
-                updated = "1714724220"
-            }
-        """)
-
         # optimized, equality alone
         self.assert_filter_has_n_results(3, """
             {
                 updated = "1714724220"
                 zip_code = "10019"
-            }
-        """)
-
-        # reproduce a bug - repeated key in AND expression
-        self.assert_filter_has_n_results(3, """
-            {
-                updated = "1714724220"
-                zip_code = "10019"
-                zip_code = "9999999999"
             }
         """)
 
@@ -340,29 +323,38 @@ class SATDataTests(BaseTest):
             }
         """)
 
-        # skip optimization, integers only so "existence optimization"
-        # kicks in first
-        self.assert_filter_has_n_results(3, """
-            {
-                updated = 1714724220
-                zip_code = 10019
-            }
-        """)
-
     def test_optimization_string_equality_integers_skipped(self):
+        # just one unique key
+        self.assert_filter_has_n_results(4, """
+            {
+                updated = "1714724220"
+                updated = "1714724220"
+            }
+        """)
+
+        # again just one unique key which is an optimization candidate
+        self.assert_filter_has_n_results(4, """
+            {
+                updated = "1714724220"
+                non_existing ?= false
+            }
+        """)
+
+        # repeated key in AND expression
+        self.assert_filter_has_n_results(0, """
+            {
+                updated = "1714724220"
+                zip_code = "10019"
+                zip_code = "9999999999"
+            }
+        """)
+
+        # integers only so "existence optimization" kicks in first
+        # ...and we never get to "equality optimization"
         self.assert_filter_has_n_results(3, """
             {
                 updated = 1714724220
                 zip_code = 10019
-            }
-        """)
-
-        # mixed content. one integer is enough to skip the optimization
-        self.assert_filter_has_n_results(1, """
-            {
-                updated = 1714724220
-                dbn = "02M296"
-                not_existing_param ?= false
             }
         """)
 


### PR DESCRIPTION
In addition to #126 this PR takes into account also integers and treats them same way as strings when it comes to optimization.
Normally, the "integers only" optimization would be applied as well, but it is preempted by the earlier [existence optimization](https://github.com/mediapredict/daffodil/blob/master/daffodil/hstore_predicate.pyx#L138), preventing it from being triggered.

Code excerpt for the record:
```
        if not breaks_existence_optimizer(children):
            return self.optimize_existence(children, sql_expr, "?&", "AND")

        if not breaks_equality_optimizer(children):
            return self.optimize_equality_and(children, sql_expr)
```
(inverted optimization ruin performance, should be avoided. Existence should be the first)
 
### Motivation
Vix: It turns out that this change speeds up the calculation by further 31% compared to the first (strings only) optimization step. 
All Non-Vix routers: from 321.8 seconds down to 239.2 seconds, which is 25% (relative to string only optimization) or 264.2 seconds down to 239.2 seconds which is only 9.5% faster.  

Conclusion this PR fixes the performance for non-Vix LFRs which got ruined by the first optimization. 

### Overall
Vix: 62% faster
Slowest vix: 27x faster
Non-vix: 9.5% faster