### PR TITLE
Add ClickHouseQueryDelegate in Cython

### DIFF
--- a/daffodil/__init__.pyx
+++ b/daffodil/__init__.pyx
@@ -1,6 +1,7 @@
 from .parser import Daffodil, TimeStamp
 from .predicate import DictionaryPredicateDelegate
 from .hstore_predicate import HStoreQueryDelegate
+from .clickhouse_query_delegate import ClickHouseQueryDelegate
 from .pretty_print import PrettyPrintDelegate
 from .key_expectation_delegate import KeyExpectationDelegate
 from .simulation_delegate import SimulationMatchingDelegate

--- a/daffodil/clickhouse_query_delegate.pyx
+++ b/daffodil/clickhouse_query_delegate.pyx
@@ -1,0 +1,71 @@
+from .parser cimport Token, BaseDaffodilDelegate
+
+
+cdef class ClickHouseQueryDelegate(BaseDaffodilDelegate):
+    cdef public str table
+
+    def __cinit__(self, table_name="hs_data"):
+        self.table = table_name
+
+    def mk_any(self, children):
+        if not children or not any(children):
+            return "0"
+
+        if isinstance(children, list):
+            children = [c for c in children if c]
+
+        return " OR ".join(f"({child})" for child in children)
+
+    def mk_all(self, children):
+        if not children or not any(children):
+            return "1"
+
+        if isinstance(children, list):
+            children = [c for c in children if c]
+
+        return " AND ".join(f"({child})" for child in children)
+
+    def mk_not_any(self, children):
+        return "NOT ({0})".format(self.mk_any(children))
+
+    def mk_not_all(self, children):
+        return "NOT ({0})".format(self.mk_all(children))
+
+    def mk_comment(self, comment, is_inline):
+        return ""
+
+    def _escape(self, s):
+        return s.replace("'", "''")
+
+    def _format_value(self, val):
+        if isinstance(val, list):
+            return "(" + ", ".join(self._format_value(v) for v in val) + ")"
+        if isinstance(val, str):
+            return "'{}'".format(self._escape(val))
+        if isinstance(val, bool):
+            return "1" if val else "0"
+        return str(val)
+
+    cdef mk_cmp(self, Token key, Token test, Token val):
+        cdef str key_str = key.content
+        cdef object val_obj = val.content
+        cdef str op = test.content
+
+        if op == "?=":
+            if val_obj is False:
+                return f"isNull({self.table}.{key_str})"
+            else:
+                return f"isNotNull({self.table}.{key_str})"
+
+        cdef str key_expr = f"{self.table}.{key_str}"
+        cdef str val_expr = self._format_value(val_obj)
+
+        if op == "in":
+            return f"{key_expr} IN {val_expr}"
+        elif op == "!in":
+            return f"{key_expr} NOT IN {val_expr}"
+        else:
+            return f"{key_expr} {op} {val_expr}"
+
+    def call(self, predicate, query=None):
+        return predicate

--- a/test/test_clickhouse.py
+++ b/test/test_clickhouse.py
@@ -1,0 +1,41 @@
+import unittest
+
+from daffodil import Daffodil, ClickHouseQueryDelegate
+
+
+class ClickHouseDelegateTests(unittest.TestCase):
+    def _render(self, fltr):
+        delegate = ClickHouseQueryDelegate("hs_data")
+        return Daffodil(fltr, delegate=delegate)()
+
+    def test_simple(self):
+        sql = self._render('zip_code = 8002')
+        self.assertEqual(sql, "(hs_data.zip_code = 8002)")
+
+    def test_medium(self):
+        fltr = '[ gender = "female"\n  gender = "male" ]'
+        expected = "((hs_data.gender = 'female') OR (hs_data.gender = 'male'))"
+        self.assertEqual(self._render(fltr), expected)
+
+    def test_advanced(self):
+        fltr = '{\n  gender ?= true\n  sat_math_avg_score >= 500\n  ![\n    zip_code = 10001\n    zip_code = 10002\n  ]\n}'
+        expected = "((isNotNull(hs_data.gender)) AND (hs_data.sat_math_avg_score >= 500) AND (NOT ((hs_data.zip_code = 10001) OR (hs_data.zip_code = 10002))))"
+        self.assertEqual(self._render(fltr), expected)
+
+    def test_timestamp(self):
+        sql = self._render('created >= timestamp(2017-06-01)')
+        self.assertEqual(sql, "(hs_data.created >= 1496275200.0)")
+
+    def test_in_operators(self):
+        sql = self._render('num_of_sat_test_takers in (50, 60)')
+        self.assertEqual(sql, "(hs_data.num_of_sat_test_takers IN (50, 60))")
+        sql = self._render('num_of_sat_test_takers !in (50)')
+        self.assertEqual(sql, "(hs_data.num_of_sat_test_takers NOT IN (50))")
+
+    def test_existence_false(self):
+        sql = self._render('zip_code ?= false')
+        self.assertEqual(sql, "(isNull(hs_data.zip_code))")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create new `ClickHouseQueryDelegate` Cython class
- re-export the new delegate from package init
- add tests for ClickHouse query generation

## Testing
- `python setup.py build_ext --inplace` *(fails: ModuleNotFoundError: No module named 'distutils')*
- `pytest -k clickhouse` *(fails: ImportError while importing ClickHouseQueryDelegate)*

------
https://chatgpt.com/codex/tasks/task_e_685eb7f770a0832cad2fce9ecd2a9193